### PR TITLE
[codex] 修复套餐查询代理回退策略

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -165,6 +165,10 @@ IP_GEO_TIMEOUT=
 # ---- 代理池 ----
 # 代理池(每行一个): 每行一个代理 URL，留空行会被忽略；为空则不使用代理
 PROXY_POOL=
+# 套餐查询网络模式: auto=本地代理可用则使用、未监听则直连；proxy=强制代理；direct=强制直连
+PLAN_CHECK_PROXY_MODE=
+# 套餐查询专用代理: 留空时 auto/proxy 从代理池选择；可能包含认证信息
+PLAN_CHECK_PROXY=
 
 # ---- CPA / Codex ----
 # 授权地址来源: cpa=由 CPA 管理接口生成授权地址；local=旧版本地生成 PKCE 授权地址

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -75,6 +75,8 @@ from config.openai_protocol import (
 # ---------- 代理池 ----------
 from config.proxy import (
     PROXY_POOL,
+    PLAN_CHECK_PROXY_MODE,
+    PLAN_CHECK_PROXY,
     pick_proxy,
     PROXY,
 )
@@ -193,7 +195,7 @@ __all__ = [
     "OPENAI_CLIENT_ID", "OPENAI_SCOPE", "OPENAI_AUDIENCE", "OPENAI_REDIRECT_URI",
     "SENTINEL_SV", "OPENAI_BUILD_ID",
     # proxy
-    "PROXY_POOL", "pick_proxy", "PROXY",
+    "PROXY_POOL", "PLAN_CHECK_PROXY_MODE", "PLAN_CHECK_PROXY", "pick_proxy", "PROXY",
     # register
     "REGISTER_EMAIL", "REGISTER_PASSWORD", "REGISTER_NAME",
     # email

--- a/config/env_loader.py
+++ b/config/env_loader.py
@@ -20,6 +20,7 @@ _LOADED = False
 SECRET_ENV_KEYS: dict[str, str] = {
     "BROWSER_USE_API_KEY": "Browser Use Cloud API Key",
     "ROXY_API_TOKEN": "RoxyBrowser 本地 API Token",
+    "PLAN_CHECK_PROXY": "套餐查询专用代理（可能包含认证信息）",
     "QQ_IMAP_PASSWORD": "QQ 邮箱 IMAP 授权码（不是 QQ 密码）",
     "GPTMAIL_API_KEY": "GPTMail API Key",
     "MAIL_NEST_API_KEY": "MailNest API Key",

--- a/config/proxy.py
+++ b/config/proxy.py
@@ -19,6 +19,17 @@ PROXY_POOL = [
     "socks5://127.0.0.1:7897",
 ]
 
+# 套餐/Plus 试用资格查询使用独立网络策略，避免批量查询被注册代理池中的
+# 临时本地代理拖垮，也避免无条件直连造成出口策略失控。
+#   auto   = 优先使用 PLAN_CHECK_PROXY 或代理池；本地代理端口未监听时回退直连
+#   proxy  = 强制使用 PLAN_CHECK_PROXY 或代理池，失败直接报错
+#   direct = 始终直连
+PLAN_CHECK_PROXY_MODE = "auto"
+
+# 套餐查询专用代理。留空时 auto/proxy 模式从 PROXY_POOL 选择。
+# 代理可能包含账号密码，因此 WebUI 会把它保存到 .env。
+PLAN_CHECK_PROXY = ""
+
 
 def pick_proxy() -> str:
     """从代理池中随机抽取一个代理 URL；池为空时返回空串（即不使用代理）。"""
@@ -29,5 +40,9 @@ def pick_proxy() -> str:
 PROXY = pick_proxy()
 
 # ---- .env overrides for WebUI editable fields ----
-apply_env_overrides(globals(), {'PROXY_POOL': 'list_str_multiline'})
+apply_env_overrides(globals(), {
+    'PROXY_POOL': 'list_str_multiline',
+    'PLAN_CHECK_PROXY_MODE': 'str',
+    'PLAN_CHECK_PROXY': 'str',
+})
 PROXY = pick_proxy()

--- a/core/chatgpt_plan.py
+++ b/core/chatgpt_plan.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import base64
+import ipaddress
 import json
 import logging
+import socket
 from datetime import datetime, timezone
 from typing import Any, Optional
-from urllib.parse import quote
+from urllib.parse import quote, urlparse
 
 from core.session import BrowserSession
 
@@ -27,6 +29,110 @@ def normalize_token(token: str) -> str:
     if token.lower().startswith("bearer "):
         token = token[7:].strip()
     return token
+
+
+def _mask_proxy(proxy: str) -> str:
+    """返回可用于日志/API 结果的代理摘要，不泄露用户名和密码。"""
+    value = str(proxy or "").strip()
+    if not value:
+        return ""
+    try:
+        parsed = urlparse(value if "://" in value else f"//{value}")
+        host = parsed.hostname or ""
+        port = f":{parsed.port}" if parsed.port else ""
+        scheme = f"{parsed.scheme}://" if parsed.scheme else ""
+        auth = "***:***@" if parsed.username or parsed.password else ""
+        return f"{scheme}{auth}{host}{port}" or "***"
+    except Exception:
+        return "***"
+
+
+def _local_proxy_status(proxy: str) -> tuple[bool, bool, str | None]:
+    """检查回环代理端口；非本地代理不做预探测，避免额外网络请求。"""
+    value = str(proxy or "").strip()
+    if not value:
+        return False, False, None
+    try:
+        parsed = urlparse(value if "://" in value else f"//{value}")
+        host = parsed.hostname or ""
+        is_loopback = host.lower() == "localhost"
+        if not is_loopback:
+            try:
+                is_loopback = ipaddress.ip_address(host).is_loopback
+            except ValueError:
+                is_loopback = False
+        if not is_loopback:
+            return False, True, None
+        if not parsed.port:
+            return True, False, "本地代理未配置端口"
+        try:
+            with socket.create_connection((host, parsed.port), timeout=0.5):
+                return True, True, None
+        except OSError as exc:
+            return True, False, f"本地代理 {host}:{parsed.port} 未监听（{type(exc).__name__}）"
+    except Exception as exc:
+        return False, False, f"代理地址解析失败（{type(exc).__name__}）"
+
+
+def resolve_plan_check_route(explicit_proxy: Optional[str] = None) -> dict:
+    """解析套餐查询的实际网络路径。
+
+    explicit_proxy 不是 None 时表示 API 调用方明确覆盖配置；空字符串代表直连。
+    """
+    if explicit_proxy is not None:
+        selected = str(explicit_proxy or "").strip()
+        return {
+            "proxy": selected,
+            "proxy_mode": "request",
+            "network_route": "proxy" if selected else "direct",
+            "proxy_used": _mask_proxy(selected) or None,
+            "proxy_fallback_reason": None,
+        }
+
+    from config import proxy as proxy_cfg
+
+    mode = str(getattr(proxy_cfg, "PLAN_CHECK_PROXY_MODE", "auto") or "auto").strip().lower()
+    if mode not in {"auto", "proxy", "direct"}:
+        raise ValueError(f"PLAN_CHECK_PROXY_MODE={mode!r} 无效，可选 auto / proxy / direct")
+    if mode == "direct":
+        return {
+            "proxy": "",
+            "proxy_mode": mode,
+            "network_route": "direct",
+            "proxy_used": None,
+            "proxy_fallback_reason": None,
+        }
+
+    selected = str(getattr(proxy_cfg, "PLAN_CHECK_PROXY", "") or "").strip()
+    if not selected:
+        selected = str(proxy_cfg.pick_proxy() or "").strip()
+    if not selected:
+        if mode == "proxy":
+            raise ValueError("套餐查询网络模式为 proxy，但未配置 PLAN_CHECK_PROXY 或 PROXY_POOL")
+        return {
+            "proxy": "",
+            "proxy_mode": mode,
+            "network_route": "direct",
+            "proxy_used": None,
+            "proxy_fallback_reason": "未配置套餐查询代理或代理池",
+        }
+
+    is_local, available, reason = _local_proxy_status(selected)
+    if mode == "auto" and is_local and not available:
+        return {
+            "proxy": "",
+            "proxy_mode": mode,
+            "network_route": "direct_fallback",
+            "proxy_used": _mask_proxy(selected),
+            "proxy_fallback_reason": reason,
+        }
+    return {
+        "proxy": selected,
+        "proxy_mode": mode,
+        "network_route": "proxy",
+        "proxy_used": _mask_proxy(selected),
+        "proxy_fallback_reason": None,
+    }
 
 
 def decode_jwt_payload_unverified(token: str) -> dict:
@@ -180,8 +286,19 @@ def check_account_plan(token: str, *, proxy: Optional[str] = None, timezone_offs
             **{k: v for k, v in claims.items() if k != "payload"},
         }
 
+    try:
+        route = resolve_plan_check_route(proxy)
+    except Exception as exc:
+        return {
+            "ok": False,
+            "checked_at": now_iso(),
+            "http_status": None,
+            "error": f"套餐查询网络配置错误: {exc}",
+            **{k: v for k, v in claims.items() if k != "payload"},
+        }
+    route_meta = {k: v for k, v in route.items() if k != "proxy"}
     url = f"https://chatgpt.com{ACCOUNTS_CHECK_PATH}?timezone_offset_min={quote(str(timezone_offset_min))}"
-    env = BrowserSession(proxy=proxy)
+    env = BrowserSession(proxy=route["proxy"])
     try:
         resp = env.session.get(url, headers=_common_headers(env, token), allow_redirects=False)
         text = resp.text or ""
@@ -196,6 +313,7 @@ def check_account_plan(token: str, *, proxy: Optional[str] = None, timezone_offs
                 "http_status": resp.status_code,
                 "error": f"HTTP {resp.status_code}",
                 "response_preview": text[:500],
+                **route_meta,
                 **{k: v for k, v in claims.items() if k != "payload"},
             }
         if not isinstance(data, dict):
@@ -205,10 +323,12 @@ def check_account_plan(token: str, *, proxy: Optional[str] = None, timezone_offs
                 "http_status": resp.status_code,
                 "error": "响应不是 JSON 对象",
                 "response_preview": text[:500],
+                **route_meta,
                 **{k: v for k, v in claims.items() if k != "payload"},
             }
         parsed = parse_accounts_check(data, token=token)
         parsed["http_status"] = resp.status_code
+        parsed.update(route_meta)
         return parsed
     except Exception as exc:
         logger.debug("套餐查询失败: %s: %s", type(exc).__name__, exc, exc_info=True)
@@ -217,5 +337,6 @@ def check_account_plan(token: str, *, proxy: Optional[str] = None, timezone_offs
             "checked_at": now_iso(),
             "http_status": None,
             "error": f"{type(exc).__name__}: {exc}",
+            **route_meta,
             **{k: v for k, v in claims.items() if k != "payload"},
         }

--- a/core/db.py
+++ b/core/db.py
@@ -720,6 +720,10 @@ def update_account_plan_check(acc_id: int | None = None, email: str | None = Non
         row["plus_trial_duration_num_periods"] = result.get("plus_trial_duration_num_periods")
         row["plus_trial_duration_period"] = result.get("plus_trial_duration_period")
         row["eligible_offer_ids"] = result.get("eligible_offer_ids") or []
+        row["plan_check_proxy_mode"] = result.get("proxy_mode")
+        row["plan_check_network_route"] = result.get("network_route")
+        row["plan_check_proxy_used"] = result.get("proxy_used")
+        row["plan_check_proxy_fallback_reason"] = result.get("proxy_fallback_reason")
         row["token_expired"] = result.get("token_expired")
         row["token_expires_at"] = result.get("token_expires_at")
         row["plan_check_result_json"] = json.dumps(result, ensure_ascii=False)

--- a/webui/app.py
+++ b/webui/app.py
@@ -166,7 +166,8 @@ def create_app() -> Flask:
             return jsonify({"ok": False, "error": "该账号没有 access_token"}), 400
         result = check_account_plan(
             token,
-            proxy=data.get("proxy", None),
+            # 未传 proxy 时使用套餐查询独立网络策略；显式传值仍可覆盖。
+            proxy=data.get("proxy") if "proxy" in data else None,
             timezone_offset_min=str(data.get("timezone_offset_min") or "-"),
         )
         db.update_account_plan_check(acc_id=int(acc.get("id")), result=result)
@@ -185,7 +186,8 @@ def create_app() -> Flask:
         if len(ids) > 500:
             return jsonify({"ok": False, "error": "单次最多查询 500 个账号"}), 400
         workers = max(1, min(16, int(data.get("workers") or 3)))
-        proxy = data.get("proxy", None)
+        # 与单账号查询保持一致：未传时使用独立网络策略。
+        proxy = data.get("proxy") if "proxy" in data else None
         timezone_offset_min = str(data.get("timezone_offset_min") or "-")
 
         items = []
@@ -222,6 +224,8 @@ def create_app() -> Flask:
                 "ok": bool(result.get("ok")),
                 "plan": result.get("current_plan_type"),
                 "plus_trial_eligible": bool(result.get("plus_trial_eligible")),
+                "network_route": result.get("network_route"),
+                "proxy_fallback_reason": result.get("proxy_fallback_reason"),
                 "error": result.get("error"),
             }
 

--- a/webui/config_editor.py
+++ b/webui/config_editor.py
@@ -326,6 +326,15 @@ EDITABLE_FIELDS = [
         "key": "PROXY_POOL", "file": "proxy.py", "type": "list_str_multiline", "group": "代理池",
         "label": "代理池(每行一个)", "help": "每行一个代理 URL，留空行会被忽略；为空则不使用代理",
     },
+    {
+        "key": "PLAN_CHECK_PROXY_MODE", "file": "proxy.py", "type": "str", "group": "代理池",
+        "label": "套餐查询网络模式", "help": "auto=本地代理可用则走代理、未监听则直连；proxy=强制代理；direct=强制直连",
+    },
+    {
+        "key": "PLAN_CHECK_PROXY", "file": "proxy.py", "type": "str", "group": "代理池",
+        "label": "套餐查询专用代理", "help": "可选；留空时 auto/proxy 从代理池选择。可能包含认证信息，仅保存到 .env",
+        "storage": "env", "secret": True,
+    },
     # ---- 接码平台 ----
     # ---- CPA / Codex 授权 ----
     {

--- a/webui/templates/index.html
+++ b/webui/templates/index.html
@@ -933,7 +933,11 @@ function _planCell(r) {
   const err = r.plan_check_error || '';
   const plan = (r.current_plan_type || r.plan_type || '-').toString();
   const checked = r.plan_checked_at ? `查询: ${esc(r.plan_checked_at)}` : '未查询实时套餐';
-  const title = err ? esc(err) : checked;
+  const route = (r.plan_check_network_route || '').toString();
+  const routeLabel = route === 'proxy' ? `网络: 代理${r.plan_check_proxy_used ? ` (${r.plan_check_proxy_used})` : ''}` :
+    route === 'direct_fallback' ? `网络: 直连回退${r.plan_check_proxy_fallback_reason ? ` (${r.plan_check_proxy_fallback_reason})` : ''}` :
+    route === 'direct' ? '网络: 直连' : '';
+  const title = [err ? esc(err) : checked, routeLabel].filter(Boolean).join('；');
   if (err && ok === false) return `<span class="pill status-failed" title="${title}">查询失败</span>`;
   const lower = plan.toLowerCase();
 
@@ -1150,7 +1154,8 @@ async function checkOnePlan(id, btn) {
     const ret = r.result || {};
     if (ret.ok) {
       const trial = ret.plus_trial_eligible ? '，有 Plus 试用资格' : '';
-      showToast(`套餐：${ret.current_plan_type || '-'}${trial}`);
+      const route = ret.network_route === 'proxy' ? '代理' : ret.network_route === 'direct_fallback' ? '直连回退' : '直连';
+      showToast(`套餐：${ret.current_plan_type || '-'}${trial}（${route}）`);
     } else {
       showToast('查询失败: ' + (ret.error || 'unknown'));
     }


### PR DESCRIPTION
## 变更内容

- 为套餐与 Plus 试用资格查询新增 `auto`、`proxy`、`direct` 三种独立网络模式
- `auto` 模式优先使用专用代理或代理池，本地回环代理未监听时自动回退直连
- 单账号与批量查询统一记录实际网络路径、代理摘要和回退原因
- 在 WebUI 配置页增加套餐查询网络模式与专用代理配置
- 代理认证信息在查询结果和界面中脱敏

## Bug 出现场景

该问题主要出现在以下组合场景：

1. 项目代理池配置了本地代理，例如 `socks5://127.0.0.1:7897`。
2. 用户通过 RoxyBrowser 等独立浏览器出口完成注册，账号和 Access Token 均已正常保存。
3. 后续本地代理程序未启动、监听端口发生变化，或者配置的代理协议与实际端口不一致。
4. 用户在账号页面点击“查套餐”，或选择多个账号执行批量套餐查询。

此时套餐查询会自动继承注册代理池，并尝试连接已经失效的本地代理，最终返回类似错误：

```text
Failed to connect to 127.0.0.1 port 7897
```

账号本身和 Access Token 实际有效，直连查询可返回 HTTP 200，但界面会显示“查询失败”，无法判断当前套餐及 Plus 免费试用资格。单账号和批量查询都会受到影响。

## 问题原因

套餐查询与注册流程共用了同一代理池，没有独立的网络策略，也没有判断本地回环代理端口是否正在监听。RoxyBrowser 可以通过自身环境代理成功注册，但套餐查询的 HTTP 会话仍可能被无效的项目代理池阻断。

## 预期行为

- 套餐查询可以独立选择网络策略，不干扰注册代理。
- 本地代理可用时继续使用代理。
- `auto` 模式下，本地代理未监听时安全回退直连。
- 强制代理模式下不切换出口，失败原因应清晰可见。

## 影响范围

- 不改变注册流程、RoxyBrowser 或其他驱动的代理行为
- `auto` 只对未监听的本地回环代理执行直连回退
- `proxy` 模式继续保持强制代理，失败时不会切换出口
- `direct` 模式始终直连

## 验证

- Python 语法检查通过
- `git diff --check` 通过
- 单账号套餐查询返回 HTTP 200
- 批量套餐查询成功
- Plus 免费试用资格识别成功
- `auto` 模式正确记录 `direct_fallback` 及本地代理未监听原因
