### PR TITLE
fix: 查活网络预检失败自动换IP重试 + 补跑等待OTP输入框

### DIFF
--- a/core/account_liveness.py
+++ b/core/account_liveness.py
@@ -24,6 +24,53 @@ _LOG_DIR = Path(__file__).resolve().parent.parent / "注册日志"
 _RUNNING: set[str] = set()
 _RUNNING_LOCK = threading.Lock()
 
+# 查活网络预检失败（403/429/代理/超时等）多为出口 IP 被 CF 标记或代理池抖动，
+# 视为可换新 IP 重试；账号本身问题（废号/邮箱错误等）不重试。
+_RETRYABLE_NETWORK_HINTS = (
+    "403", "429", "502", "503", "504",
+    "proxy", "socks", "timeout", "timed out",
+    "connection", "closed", "reset",
+)
+
+
+def _is_retryable_network_error(exc: BaseException) -> bool:
+    if isinstance(exc, AccountUnusableError):
+        return False
+    text = str(exc or "").lower()
+    return any(h in text for h in _RETRYABLE_NETWORK_HINTS)
+
+
+def _network_preflight_with_retry(email: str, proxy: str | None, max_attempts: int = 4) -> tuple[BrowserSession, str]:
+    """Providers → CSRF → Signin 网络预检；失败换新 IP 重试（每轮新会话新代理）。"""
+    session: BrowserSession | None = None
+    last_exc: BaseException | None = None
+    for attempt in range(1, max_attempts + 1):
+        if session is not None:
+            try:
+                session.session.close()
+            except Exception:
+                pass
+        session = BrowserSession(proxy=proxy if proxy else None)
+        logger.info(
+            "[查活] 会话创建完成：proxy=%s device_id=%s（网络预检第 %s/%s 次）",
+            session.proxy or "配置随机/直连", session.device_id, attempt, max_attempts,
+        )
+        try:
+            get_providers(session)
+            csrf = get_csrf_token(session)
+            authorize_url = signin_openai(session, csrf, email)
+            return session, authorize_url
+        except Exception as exc:
+            last_exc = exc
+            if attempt >= max_attempts or not _is_retryable_network_error(exc):
+                raise
+            logger.warning(
+                "[查活] 网络预检失败（%s/%s），换新 IP 重试：%s",
+                attempt, max_attempts, str(exc)[:200],
+            )
+            time.sleep(2)
+    raise RuntimeError(f"网络预检多次失败：{last_exc}")
+
 
 def _now() -> str:
     return datetime.now().isoformat(timespec="seconds")
@@ -57,6 +104,19 @@ def _validate_with_retry(session: BrowserSession, email: str, otp_after_ts: floa
             logger.warning("[查活] OTP 无效/过期，重新发送后再取：%s", str(exc)[:180])
             send_email_otp(session)
             # 以“重新发送请求完成后”为新基准，避免刚刚失败的上一封旧码再次被 after 容忍窗口命中。
+            otp_after_ts = time.time()
+            current_otp = None
+            time.sleep(1)
+        except Exception as exc:
+            # 提交 OTP 后的网络抖动（连接断开/超时/代理波动）：同一会话重发验证码再验证一次。
+            if attempt >= max_otp_attempts or not _is_retryable_network_error(exc):
+                raise
+            last_exc = exc
+            logger.warning("[查活] OTP 验证网络抖动，重新发送后再取（%s/%s）：%s", attempt, max_otp_attempts, str(exc)[:180])
+            try:
+                send_email_otp(session)
+            except Exception:
+                raise
             otp_after_ts = time.time()
             current_otp = None
             time.sleep(1)
@@ -106,11 +166,7 @@ def check_account_liveness(email: str, proxy: str | None = None, *, clear_log: b
         logger.info("[查活] 日志文件：%s", path)
         logger.info("[查活] 开始重新登录：%s", email)
         logger.info("[查活] 流程：Providers → CSRF → Signin → Authorize → 邮箱 OTP → OAuth callback → Session/AT")
-        session = BrowserSession(proxy=proxy if proxy else None)
-        logger.info("[查活] 会话创建完成：proxy=%s device_id=%s", session.proxy or "配置随机/直连", session.device_id)
-        get_providers(session)
-        csrf = get_csrf_token(session)
-        authorize_url = signin_openai(session, csrf, email)
+        session, authorize_url = _network_preflight_with_retry(email, proxy)
 
         otp_after_ts = time.time()
         final_url = follow_authorize(session, authorize_url)

--- a/core/roxy_codex_oauth.py
+++ b/core/roxy_codex_oauth.py
@@ -29,6 +29,7 @@ from core.roxy_registration import (
     _clear_otp_inputs,
     _email_otp_page_state,
     _is_email_verification_page,
+    _is_login_password_page,
     _click_passwordless_signup_if_present,
 )
 
@@ -209,6 +210,37 @@ def _maybe_click_passwordless_after_email(driver, email: str, timeout: int = 18)
         logger.info("[Codex][Browser] 已点击一次性验证码入口，未立即检测到 OTP 页，继续后续 OTP 轮询")
 
 
+def _wait_for_otp_input(driver, timeout: int = 30) -> None:
+    """验证码已收到但 OTP 输入框可能尚未出现（点完一次性验证码后常有中间页/延迟渲染）。
+
+    等待期间若仍停留在登录密码页，则补点一次性验证码入口（最多 2 次、间隔 6s）；
+    超时仍未出现时打印页面状态便于定位。
+    """
+    end = time.time() + timeout
+    passwordless_retries = 0
+    while time.time() < end:
+        if _is_email_verification_page(driver):
+            return
+        if _is_login_password_page(driver) and passwordless_retries < 2:
+            passwordless_retries += 1
+            result = _click_passwordless_signup_if_present(driver)
+            if result.get("ok"):
+                logger.info("[Codex][Browser] 仍停留登录密码页，补点一次性验证码入口：%s", result.get("reason"))
+                human_delay("form")
+            time.sleep(6)
+            continue
+        time.sleep(0.8)
+    state = _email_otp_page_state(driver)
+    logger.warning(
+        "[Codex][Browser] 等待 OTP 输入框超时，页面 url=%s inputs=%s buttons=%s 文本前300字=%s",
+        str(state.get("url") or ""),
+        len(state.get("inputs") or []),
+        [(b.get("text") or "")[:24] for b in (state.get("buttons") or [])][:8],
+        str(state.get("text") or "")[:300],
+    )
+    raise RuntimeError("等待 OTP 输入框超时，页面未出现验证码输入框")
+
+
 def _fill_email_and_otp(driver, email: str, otp_provider, auth_url: str) -> None:
     otp_after_ts = time.time()
     logger.info("[Codex][Browser] 打开授权地址")
@@ -283,6 +315,7 @@ def _fill_email_and_otp(driver, email: str, otp_provider, auth_url: str) -> None
             continue
         used_codes.add(str(code))
         logger.info("[Codex][Browser] 邮箱 OTP 收到：%s", code)
+        _wait_for_otp_input(driver, timeout=30)
         _clear_otp_inputs(driver)
         _type_otp(driver, code)
         logger.info("[Codex][Browser] 已填写邮箱 OTP")
@@ -428,13 +461,9 @@ def _read_email_otp_validate_dead_code(driver) -> str:
     return ""
 
 
-def _is_email_verification_page(driver) -> bool:
-    try:
-        url = str(driver.current_url or "").lower()
-        return "email-verification" in url
-    except Exception:
-        return False
-
+# 邮箱验证码页判断复用 roxy_registration 的强版本（URL + 输入框属性识别，
+# 且明确排除 /log-in/password），不使用本地弱化版，避免点完一次性验证码后
+# 页面已渲染 OTP 输入框却因 URL 不含 email-verification 而识别失败。
 
 def _wait_after_email_otp_submit(driver, timeout: int = 45) -> str:
     """


### PR DESCRIPTION
## 背景

- **查活（liveness check）**：纯协议驱动网络预检打 `chatgpt.com/api/auth/providers` 时，代理池偶发撞上被 Cloudflare 标记的出口 IP → HTTP 403；或代理池抖动 → SOCKS 连接失败（curl 97）。原实现遇错即失败、不重试，查活成功率低。
- **补跑 Codex（roxy 驱动）**：点完"一次性验证码"后，验证码已收到但页面 OTP 输入框可能尚未渲染/仍停留在登录密码页，直接填码报"找不到 OTP 输入框"。

## 改动

### core/account_liveness.py
- 新增 `_is_retryable_network_error()`：区分网络层可重试错误（403/429/5xx/代理/超时/连接断开）与账号本身问题（废号不重试）
- 新增 `_network_preflight_with_retry()`：Providers→CSRF→Signin 网络预检失败自动换新 IP（新会话新代理）重试，最多 4 次
- `_validate_with_retry`：OTP 验证遇网络抖动自动重发验证码重试

### core/roxy_codex_oauth.py
- 删除本地弱版 `_is_email_verification_page`（仅按 URL 判断），改用 `roxy_registration` 的强版（URL + 输入框属性识别，且排除 /log-in/password）
- 新增 `_wait_for_otp_input()`：收到验证码后等待 OTP 输入框出现（30s），仍停留登录密码页自动补点一次性验证码入口，超时打印页面状态便于定位
- 填码前调用 `_wait_for_otp_input`

## 验证

- 查活完整跑通：providers → CSRF → signin → 邮箱 OTP → OAuth callback → session，结果 `live`（plan=plus）
- 补跑：收到 OTP 后能正确等待并填入验证码输入框