### PR TITLE
fix: 邮箱OTP提交超时误判+重发死等+接码余额不足止损

### DIFF
--- a/core/roxy_codex_oauth.py
+++ b/core/roxy_codex_oauth.py
@@ -1123,12 +1123,22 @@ def _do_phone_verification_if_present(driver) -> None:
                 return
             except Exception as exc:
                 last_err = exc
-                logger.warning("[Codex][Browser] 手机验证尝试失败，换号：%s", str(exc)[:240])
+                err_text = str(exc) or ""
+                logger.warning("[Codex][Browser] 手机验证尝试失败，换号：%s", err_text[:240])
                 if activation_id:
                     try:
                         sms_provider.cancel(activation_id, http)
                     except Exception:
                         pass
+                # 余额不足 / 无可用号码：重试多少次都不会成功，立即失败止损，
+                # 避免白等 N 轮换号重试（每轮还要刷新页面 + 随机等待）。
+                if any(k in err_text for k in (
+                    "NO_BALANCE", "NO_NUMBERS", "BALANCE", "余额不足",
+                    "暂无可用号码", "没有可用号码", "insufficient", "not enough balance",
+                )):
+                    raise RuntimeError(
+                        f"接码平台余额不足或无可用号码，已停止换号止损：{err_text[:180]}"
+                    ) from exc
                 if "invalid_auth_step" in str(exc):
                     raise RuntimeError(
                         "手机号流程进入 invalid_auth_step，说明授权状态还未从 email-verification 正常跳转或已失效；"

--- a/core/roxy_registration.py
+++ b/core/roxy_registration.py
@@ -1155,8 +1155,13 @@ def _click_resend_email_otp(driver, timeout: int = 20) -> dict:
     raise RuntimeError(f"找不到可点击的重新发送验证码按钮: last={last}, state={_email_otp_page_state(driver)}")
 
 
-def _wait_after_email_otp_submit(driver, timeout: int = 10) -> str:
-    """提交 OTP 后等待页面离开验证码页；仍在验证码页且有错误/输入框则认为验证码无效。"""
+def _wait_after_email_otp_submit(driver, timeout: int = 30) -> str:
+    """提交 OTP 后等待页面离开验证码页。
+
+    只有页面明确出现验证码错误（aria-invalid / 错误文案）才判定为无效；
+    网络慢时页面跳转可能超过 10s，超时后只要没有错误标记就按 accepted 处理，
+    避免把已提交成功的验证码误判为失败后误点“重新发送”把流程搞乱。
+    """
     end = time.time() + timeout
     last = {}
     while time.time() < end:
@@ -1168,8 +1173,18 @@ def _wait_after_email_otp_submit(driver, timeout: int = 10) -> str:
         if invalid or (last.get('errors') or []):
             return 'invalid'
     if _is_email_verification_page(driver):
-        logger.warning("%s[OTP] 提交后仍停留验证码页，按验证码无效/过期处理 snapshot=%s", _log_prefix(driver), _email_otp_page_state(driver))
-        return 'invalid'
+        # 超时仍停留：若无明确错误标记，判定为提交成功、跳转缓慢，按 accepted 放行。
+        has_error_mark = bool(last.get('errors')) or any(
+            str(i.get('ariaInvalid') or '').lower() == 'true' for i in (last.get('inputs') or [])
+        )
+        if has_error_mark:
+            logger.warning("%s[OTP] 提交后仍停留验证码页且存在错误标记，按验证码无效处理 snapshot=%s", _log_prefix(driver), last)
+            return 'invalid'
+        logger.warning(
+            "%s[OTP] 提交后 %ss 仍在验证码页但无错误标记，按跳转缓慢处理（accepted） snapshot=%s",
+            _log_prefix(driver), timeout, last
+        )
+        return 'accepted'
     return 'accepted'
 
 
@@ -2014,6 +2029,21 @@ def run_roxy_registration(email: str, name: str, birthday: str, proxy: str = Non
                 except Exception as exc:
                     if otp_attempt >= max_otp_attempts:
                         raise
+                    # 兜底：OpenAI 重发验证码时常常是同一封邮件（时间戳不变），
+                    # after_ts 过滤会把它当成旧邮件忽略。先宽松取最新一条验证码，
+                    # 取到就直接用它重试提交，避免误点“重新发送”后死等。
+                    fallback_otp = None
+                    try:
+                        fallback_otp = wait_for_otp(email, after_ts=0.0, max_wait=15, poll_interval=3)
+                    except Exception:
+                        fallback_otp = None
+                    if fallback_otp:
+                        logger.info(
+                            "[Roxy注册][OTP] 取码接口超时但宽松取到最新验证码，直接重试提交：%s (fallback)",
+                            fallback_otp,
+                        )
+                        current_otp = fallback_otp
+                        continue
                     logger.warning(
                         "[Roxy注册][OTP] 一直未收到验证码，点击“重新发送电子邮件”后继续等待（下一轮 %s/%s）：%s: %s",
                         otp_attempt + 1,
@@ -2038,7 +2068,7 @@ def run_roxy_registration(email: str, name: str, birthday: str, proxy: str = Non
             except Exception as exc:
                 logger.info("[Roxy注册][OTP] 未找到显式提交按钮，继续等待页面状态：%s", str(exc)[:120])
 
-            outcome = _wait_after_email_otp_submit(driver, timeout=10)
+            outcome = _wait_after_email_otp_submit(driver, timeout=30)
             if outcome == 'accepted':
                 break
             if otp_attempt >= max_otp_attempts:


### PR DESCRIPTION
## 修复内容（3 个注册/补跑卡点）

### 1. 邮箱 OTP 提交超时误判（注册机主流程 `roxy_registration.py`）
- `_wait_after_email_otp_submit` 等待时间 `10s → 30s`
- 超时后**只有页面明确出现验证码错误标记**（aria-invalid / 错误文案）才判定无效
- 之前：网络慢时（代理 20s 延迟）验证码已提交成功但页面 10s 内没跳转，被误判"验证码无效"→ 误点"重新发送"→ 页面状态被搞乱，用户肉眼看到浏览器已到姓名/年龄页、终端还在拉验证码

### 2. 邮箱验证码重发死等（`roxy_registration.py`）
- 取码超时后先**宽松取最新一条验证码兜底**（`after_ts=0`）
- 原因：OpenAI 重发验证码时常发**同一封邮件**（时间戳不变），原 `after_ts` 时间戳过滤把它当旧邮件忽略 → 永远等不到 → 3 轮全废

### 3. 接码平台余额不足止损（补跑 `roxy_codex_oauth.py`）
- 手机验证换号时遇到 `NO_BALANCE` / `NO_NUMBERS` → **立即失败**
- 之前：余额不足还傻等 10 轮换号（每轮刷新页面+随机等待，白耗 2-3 分钟）

## 验证
- `py_compile` 通过
- 已实测：修复前 OTP 提交后被误判无效并触发重发循环；修复后 30s 等待窗口内正常跳转放行